### PR TITLE
EntityDataMapperService::mapEntity improvements

### DIFF
--- a/DataMapping/EntityDataMapperService.php
+++ b/DataMapping/EntityDataMapperService.php
@@ -72,7 +72,9 @@ class EntityDataMapperService
     private function getAuthenticatedUser()
     {
         // Both TokenStorage and SecurityContext share "getToken" method
-        return $this->tokenStorage->getToken()->getUser();
+        if ($token = $this->tokenStorage->getToken()) {
+            return $token->getUser();
+        }
     }
 
     /**

--- a/DataMapping/EntityDataMapperService.php
+++ b/DataMapping/EntityDataMapperService.php
@@ -238,9 +238,12 @@ class EntityDataMapperService
                                 /* @var ComplexFieldValueConverterInterface $converter */
                                 if ($converter->isResponsible($value, $fieldName, $metadata)) {
                                     $convertedValue = $converter->convert($value, $fieldName, $metadata);
+                                    break;
                                 }
                             }
-                        } else {
+                        }
+
+                        if (null === $convertedValue) {
                             $convertedValue = $this->convertValue($value, $mapping['type']);
                         }
 

--- a/Tests/DataMapping/EntityDataMapperServiceTest.php
+++ b/Tests/DataMapping/EntityDataMapperServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Sli\ExtJsIntegrationBundle\Tests\DataMapping;
+
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Sli\ExtJsIntegrationBundle\DataMapping\EntityDataMapperService;
+use Sli\ExtJsIntegrationBundle\Tests\AbstractDatabaseTestCase;
+use Sli\ExtJsIntegrationBundle\Tests\DummyUser;
+
+/**
+ * @author Sergei Vizel <sergei.vizel@gmail.com>
+ */ 
+class EntityDataMapperServiceTest extends AbstractDatabaseTestCase
+{
+    /**
+     * @var EntityDataMapperService $mapper
+     */
+    private $mapper;
+
+    public function setUp()
+    {
+        /* @var TokenStorageInterface $ts */
+        $ts = self::$kernel->getContainer()->get('security.token_storage');
+
+        $qb = self::$builder->buildQueryBuilder(DummyUser::clazz(), array(
+            'filter' => array(
+                array('property' => 'id', 'value' => 'eq:1')
+            )
+        ));
+        /* @var DummyUser[] $users */
+        $users = $qb->getQuery()->getResult();
+
+        $token = new UsernamePasswordToken($users[0], null, 'main', ['ROLE_ADMIN']);
+        $ts->setToken($token);
+
+        $this->mapper = self::$kernel->getContainer()->get('sli.extjsintegration.entity_data_mapper');
+    }
+
+    public function testConvertDate()
+    {
+        $date = $this->mapper->convertDate('02.01.06');
+
+        $this->assertInstanceOf('DateTime', $date);
+        $this->assertEquals('02', $date->format('d'));
+        $this->assertEquals('01', $date->format('m'));
+        $this->assertEquals('06', $date->format('y'));
+
+        $date = $this->mapper->convertDate('02.01.06', true);
+
+        $this->assertEquals('2006-01-02', $date);
+    }
+
+    public function testConvertDateTime()
+    {
+        $date = $this->mapper->convertDateTime('02.01.06 15:04');
+
+        $this->assertInstanceOf('DateTime', $date);
+        $this->assertEquals('02', $date->format('d'));
+        $this->assertEquals('01', $date->format('m'));
+        $this->assertEquals('06', $date->format('y'));
+        $this->assertEquals('15', $date->format('G'));
+        $this->assertEquals('04', $date->format('i'));
+    }
+
+    public function testConvertBoolean()
+    {
+        $this->assertTrue($this->mapper->convertBoolean(1));
+        $this->assertTrue($this->mapper->convertBoolean('on'));
+        $this->assertTrue($this->mapper->convertBoolean('true'));
+        $this->assertTrue($this->mapper->convertBoolean(true));
+
+        $this->assertFalse($this->mapper->convertBoolean(0));
+        $this->assertFalse($this->mapper->convertBoolean('off'));
+        $this->assertFalse($this->mapper->convertBoolean('false'));
+        $this->assertFalse($this->mapper->convertBoolean(false));
+    }
+
+    public function testMapEntity()
+    {
+        $user = new DummyUser();
+        $userParams = array(
+            'email' => 'john.doe@example.org',
+            'isActive' => 'off',
+            'accessLevel' => '5',
+            'meta' => array(
+                'foo' => 'bar',
+            ),
+        );
+
+        $this->mapper->mapEntity($user, $userParams, array_keys($userParams));
+
+        $this->assertEquals($userParams['email'], $user->email);
+        $this->assertFalse($user->isActive);
+        $this->assertEquals(5, $user->accessLevel);
+        $this->assertEquals($userParams['meta'], $user->meta);
+    }
+}

--- a/Tests/DummyEntities.php
+++ b/Tests/DummyEntities.php
@@ -21,6 +21,21 @@ class DummyUser implements PreferencesAwareUserInterface
     public $id;
 
     /**
+     * @Orm\Column(type="boolean")
+     */
+    public $isActive;
+
+    /**
+     * @Orm\Column(type="integer")
+     */
+    public $accessLevel;
+
+    /**
+     * @Orm\Column(type="string", nullable=true)
+     */
+    public $email;
+
+    /**
      * @Orm\Column(type="string", nullable=true)
      */
     public $firstname;
@@ -52,18 +67,58 @@ class DummyUser implements PreferencesAwareUserInterface
     public $price = 0;
 
     /**
+     * @Orm\Column(type="json_array", nullable=false)
+     */
+    public $meta = array();
+
+    public function setActive($isActive)
+    {
+        $this->isActive = $isActive;
+    }
+
+    public function setAccessLevel($accessLevel)
+    {
+        $this->accessLevel = $accessLevel;
+    }
+
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+
+    public function setMeta($meta)
+    {
+        $this->meta = $meta;
+    }
+
+    /**
      * @inheritDoc
      */
     public function getPreferences()
     {
         return array(
-            PreferencesAwareUserInterface::SETTINGS_DATE_FORMAT => 'd.m.Y'
+            PreferencesAwareUserInterface::SETTINGS_DATE_FORMAT => 'd.m.y',
+            PreferencesAwareUserInterface::SETTINGS_DATETIME_FORMAT => 'd.m.y H:i',
+            PreferencesAwareUserInterface::SETTINGS_MONTH_FORMAT => 'm.Y',
         );
     }
 
-    public function __construct()
+    public function __construct($email = null, $accessLevel = 0, $isActive = true)
     {
+        $this->email = $email;
+        $this->accessLevel = $accessLevel;
+        $this->isActive = $isActive;
+
         $this->groups = new ArrayCollection();
+    }
+
+    public function __toString()
+    {
+        return implode('-', array(
+            $this->id,
+            $this->firstname,
+            $this->lastname,
+        ));
     }
 
     static public function clazz()


### PR DESCRIPTION
This fix solves problem for this type of entity:

``` php
<?php

class SomeEntity
{
    /**
     * @ORM\Column(type="json", nullable=false)
     */
    private array $meta = array();

    public function setMeta(array $meta)
    {
        $this->meta = $meta;
    }
}
```

Without fix, when I try to map this data:

``` php
<?php
array(
    'meta' => array(
        'foo' => 'bar',
    ),
);
```

I see an error that `meta` cannot be `NULL`
